### PR TITLE
Remove unused dotenv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "dotenv": "^8.2.0",
         "ibm-cos-sdk": "^1.10.0",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
@@ -696,14 +695,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -3561,11 +3552,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "Victor Shinya <vshinya@br.ibm.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "dotenv": "^8.2.0",
     "ibm-cos-sdk": "^1.10.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",


### PR DESCRIPTION
After the improvement to run the function on IBM Cloud Functions, the `dotenv` package was no longer required for this project.